### PR TITLE
[FEAT] 주문 수락 api (#49)

### DIFF
--- a/application-admin/src/main/kotlin/org/fastcampus/applicationadmin/order/controller/OrderController.kt
+++ b/application-admin/src/main/kotlin/org/fastcampus/applicationadmin/order/controller/OrderController.kt
@@ -10,6 +10,8 @@ import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -39,5 +41,14 @@ class OrderController(
         val response = orderService.getOrdersByStoreIdAndStatusWithPeriod(storeId, status.toOrderStatus(), startDate, endDate, page, size)
         return ResponseEntity
             .ok(APIResponseDTO(HttpStatus.OK.value(), HttpStatus.OK.reasonPhrase, response))
+    }
+
+    @PatchMapping("/{orderId}/accept")
+    fun acceptOrder(
+        @PathVariable orderId: String,
+    ): ResponseEntity<APIResponseDTO<Nothing?>> {
+        orderService.acceptOrder(orderId)
+        return ResponseEntity
+            .ok(APIResponseDTO(HttpStatus.OK.value(), HttpStatus.OK.reasonPhrase, null))
     }
 }

--- a/application-admin/src/main/kotlin/org/fastcampus/applicationadmin/order/service/OrderService.kt
+++ b/application-admin/src/main/kotlin/org/fastcampus/applicationadmin/order/service/OrderService.kt
@@ -8,6 +8,7 @@ import org.fastcampus.common.dto.OffSetBasedDTO
 import org.fastcampus.order.entity.Order
 import org.fastcampus.order.entity.OrderMenu
 import org.fastcampus.order.entity.OrderMenuOptionGroup
+import org.fastcampus.order.exception.OrderException
 import org.fastcampus.order.repository.OrderMenuOptionGroupRepository
 import org.fastcampus.order.repository.OrderMenuOptionRepository
 import org.fastcampus.order.repository.OrderMenuRepository
@@ -52,6 +53,12 @@ class OrderService(
             totalItems = orders.totalItems,
             hasNext = orders.hasNext,
         )
+    }
+
+    fun acceptOrder(orderId: String) {
+        val order = orderRepository.findById(orderId) ?: throw OrderException.OrderNotFound(orderId)
+        order.accept()
+        orderRepository.save(order)
     }
 
     private fun convertIntoOrderInquiryResponse(order: Order): OrderInquiryResponse {

--- a/domains/order/src/main/kotlin/org/fastcampus/order/entity/Order.kt
+++ b/domains/order/src/main/kotlin/org/fastcampus/order/entity/Order.kt
@@ -1,5 +1,6 @@
 package org.fastcampus.order.entity
 
+import org.fastcampus.order.exception.OrderException
 import java.time.LocalDateTime
 
 /**
@@ -14,7 +15,7 @@ data class Order(
     val jibunAddress: String?,
     val detailAddress: String?,
     val tel: String?,
-    val status: Status,
+    var status: Status,
     val orderTime: LocalDateTime,
     val orderSummary: String?,
     val type: Type,
@@ -25,6 +26,14 @@ data class Order(
     val deliveryPrice: Long?,
     val paymentPrice: Long,
 ) {
+    fun accept() {
+        // 주문접수상태만 주문수락가능
+        if (!this.status.equals(Status.RECEIVE)) {
+            throw OrderException.OrderCanNotAccept(this.id)
+        }
+        this.status = Status.ACCEPT
+    }
+
     enum class Status(
         val code: String,
         val desc: String,

--- a/domains/order/src/main/kotlin/org/fastcampus/order/exception/OrderException.kt
+++ b/domains/order/src/main/kotlin/org/fastcampus/order/exception/OrderException.kt
@@ -1,6 +1,10 @@
 package org.fastcampus.order.exception
 
 open class OrderException(message: String) : RuntimeException(message) {
+    data class OrderNotFound(val orderId: String) : OrderException("주문을 찾을 수 없습니다.")
+
+    data class OrderCanNotAccept(val orderId: String) : OrderException("주문 수락이 불가능한 주문입니다.")
+
     data class StoreNotFound(val storeId: String) : OrderException("가게를 찾을 수 없습니다.")
 
     data class StoreClosed(val storeId: String) : OrderException("가게의 영업이 종료되어 주문이 불가능합니다.")


### PR DESCRIPTION
- 점추측에서 주문 수락을 했을 경우의 api 입니다.
- 단순히 주문상태변화만 발생하며, 주문상태가 RECEIVE(주문접수) 가 아닌 상태에서 해당 api를 호출하면 exception이 발생합니다.