### PR TITLE
[FEAT] 주문취소 API 구현 (#11)

### DIFF
--- a/application-admin/build.gradle.kts
+++ b/application-admin/build.gradle.kts
@@ -23,4 +23,5 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("com.auth0:java-jwt:4.2.1")
+    implementation("org.springframework.retry:spring-retry")
 }

--- a/application-admin/src/test/kotlin/org/fastcampus/applicationadmin/service/OrderServiceTest.kt
+++ b/application-admin/src/test/kotlin/org/fastcampus/applicationadmin/service/OrderServiceTest.kt
@@ -86,10 +86,10 @@ class OrderServiceTest {
     @Test
     fun `must change order status to accept when admin accept order`() {
         // given
-        val order = createOrderFixture()
-        order.status = Order.Status.RECEIVE
+        val order = createOrderFixture().copy(status = Order.Status.RECEIVE)
 
         `when`(orderRepository.findById(order.id)).thenReturn(order)
+        `when`(orderRepository.save(order)).thenReturn(order)
 
         // when
         orderService.acceptOrder(order.id)
@@ -103,8 +103,7 @@ class OrderServiceTest {
     @Test
     fun `must throw exception when admin try to accept order witch has not receive status`() {
         // given
-        val order = createOrderFixture()
-        order.status = Order.Status.CANCEL
+        val order = createOrderFixture().copy(status = Order.Status.CANCEL)
 
         `when`(orderRepository.findById(order.id)).thenReturn(order)
 

--- a/application-client/build.gradle.kts
+++ b/application-client/build.gradle.kts
@@ -23,4 +23,5 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("com.auth0:java-jwt:4.2.1")
+    implementation("org.springframework.retry:spring-retry")
 }

--- a/application-client/src/main/kotlin/org/fastcampus/applicationclient/order/controller/OrderController.kt
+++ b/application-client/src/main/kotlin/org/fastcampus/applicationclient/order/controller/OrderController.kt
@@ -5,6 +5,7 @@ import org.fastcampus.applicationclient.order.controller.dto.request.OrderCreati
 import org.fastcampus.applicationclient.order.controller.dto.response.OrderCreationResponse
 import org.fastcampus.applicationclient.order.controller.dto.response.OrderDetailResponse
 import org.fastcampus.applicationclient.order.controller.dto.response.OrderResponse
+import org.fastcampus.applicationclient.order.service.OrderCancellationService
 import org.fastcampus.applicationclient.order.service.OrderService
 import org.fastcampus.common.dto.APIResponseDTO
 import org.fastcampus.common.dto.CursorDTO
@@ -12,6 +13,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -23,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1/orders")
 class OrderController(
     private val orderService: OrderService,
+    private val orderCancellationService: OrderCancellationService,
 ) {
     @GetMapping
     fun getOrders(
@@ -51,5 +54,14 @@ class OrderController(
     ): APIResponseDTO<OrderCreationResponse> {
         val response = orderService.createOrder(authMember.id, orderCreationRequest)
         return APIResponseDTO(HttpStatus.OK.value(), HttpStatus.OK.reasonPhrase, response)
+    }
+
+    @PatchMapping("/{orderId}/cancel")
+    fun cancelOrder(
+        @PathVariable orderId: String,
+        @AuthenticationPrincipal authMember: AuthMember,
+    ): APIResponseDTO<Nothing?> {
+        orderCancellationService.cancelOrder(orderId)
+        return APIResponseDTO(HttpStatus.OK.value(), HttpStatus.OK.reasonPhrase, null)
     }
 }

--- a/application-client/src/main/kotlin/org/fastcampus/applicationclient/order/service/OrderCancellationService.kt
+++ b/application-client/src/main/kotlin/org/fastcampus/applicationclient/order/service/OrderCancellationService.kt
@@ -1,0 +1,41 @@
+package org.fastcampus.applicationclient.order.service
+
+import org.fastcampus.order.exception.OrderException
+import org.fastcampus.order.repository.OrderRepository
+import org.fastcampus.payment.service.RefundManager
+import org.springframework.dao.OptimisticLockingFailureException
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.Recover
+import org.springframework.retry.annotation.Retryable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class OrderCancellationService(
+    private val orderRepository: OrderRepository,
+    private val refundManager: RefundManager,
+) {
+    @Transactional
+    fun cancelOrder(orderId: String) {
+        cancelOrderWithRetry(orderId)
+        refundManager.refundOrder(orderId)
+    }
+
+    // 주문취소는 주문수락, 주문거절에 대해서 race condition 이 발생하기에 낙관적락으로 동시성 이슈 처리
+    @Retryable(
+        value = [OptimisticLockingFailureException::class],
+        maxAttempts = 3,
+        backoff = Backoff(delay = 1000),
+        recover = "recoverRaceConditionOnOrder",
+    )
+    private fun cancelOrderWithRetry(orderId: String) {
+        val order = orderRepository.findById(orderId) ?: throw OrderException.OrderCanNotCancelled(orderId)
+        order.cancel()
+        orderRepository.save(order)
+    }
+
+    @Recover
+    private fun recoverRaceConditionOnOrder(orderId: String) {
+        throw OrderException.OrderCanNotCancelled(orderId)
+    }
+}

--- a/application-client/src/test/kotlin/org/fastcampus/applicationclient/fixture/OrderFixture.kt
+++ b/application-client/src/test/kotlin/org/fastcampus/applicationclient/fixture/OrderFixture.kt
@@ -1,0 +1,84 @@
+package org.fastcampus.applicationclient.fixture
+
+import org.fastcampus.order.entity.Order
+import org.fastcampus.order.entity.OrderMenu
+import org.fastcampus.order.entity.OrderMenuOption
+import org.fastcampus.order.entity.OrderMenuOptionGroup
+import java.time.LocalDateTime
+
+fun createOrderFixture(
+    id: String = "order_123",
+    storeId: String? = "store_456",
+    userId: Long? = 789L,
+    roadAddress: String? = "123 Test Street",
+    jibunAddress: String? = "123 Test Village",
+    detailAddress: String? = "Apt 101",
+    tel: String? = "010-1234-5678",
+    status: Order.Status = Order.Status.RECEIVE,
+    orderTime: LocalDateTime = LocalDateTime.now(),
+    orderSummary: String? = "2 items ordered",
+    type: Order.Type = Order.Type.DELIVERY,
+    paymentId: Long = 987L,
+    isDeleted: Boolean = false,
+    deliveryCompleteTime: LocalDateTime? = null,
+    orderPrice: Long = 10000L,
+    deliveryPrice: Long? = 3000L,
+    paymentPrice: Long = 13000L,
+): Order {
+    return Order(
+        id = id,
+        storeId = storeId,
+        userId = userId,
+        roadAddress = roadAddress,
+        jibunAddress = jibunAddress,
+        detailAddress = detailAddress,
+        tel = tel,
+        status = status,
+        orderTime = orderTime,
+        orderSummary = orderSummary,
+        type = type,
+        paymentId = paymentId,
+        isDeleted = isDeleted,
+        deliveryCompleteTime = deliveryCompleteTime,
+        orderPrice = orderPrice,
+        deliveryPrice = deliveryPrice,
+        paymentPrice = paymentPrice,
+    )
+}
+
+fun createOrderMenuFixture(
+    id: Long? = 1L,
+    orderId: String? = "order_123",
+    menuId: String = "menu_001",
+    menuName: String = "Cheese Pizza",
+    menuQuantity: Long = 2,
+    menuPrice: Long = 10000L,
+    totalPrice: Long = menuQuantity * menuPrice,
+): OrderMenu {
+    return OrderMenu(
+        id = id,
+        orderId = orderId,
+        menuId = menuId,
+        menuName = menuName,
+        menuQuantity = menuQuantity,
+        menuPrice = menuPrice,
+        totalPrice = totalPrice,
+    )
+}
+
+fun createOrderMenuOptionGroupFixture(id: Long? = 1L, orderMenuId: Long = 1L, orderMenuOptionGroupName: String = "Extra Toppings"): OrderMenuOptionGroup {
+    return OrderMenuOptionGroup(
+        id = id,
+        orderMenuId = orderMenuId,
+        orderMenuOptionGroupName = orderMenuOptionGroupName,
+    )
+}
+
+fun createOrderMenuOptionFixture(id: Long? = 1L, orderMenuOptionGroupId: Long = 1L, menuOptionName: String = "Extra Cheese", menuOptionPrice: Long = 2000L): OrderMenuOption {
+    return OrderMenuOption(
+        id = id,
+        orderMenuOptionGroupId = orderMenuOptionGroupId,
+        menuOptionName = menuOptionName,
+        menuOptionPrice = menuOptionPrice,
+    )
+}

--- a/application-client/src/test/kotlin/org/fastcampus/applicationclient/order/service/OrderCancellationServiceTest.kt
+++ b/application-client/src/test/kotlin/org/fastcampus/applicationclient/order/service/OrderCancellationServiceTest.kt
@@ -1,0 +1,62 @@
+package org.fastcampus.applicationclient.order.service
+
+import org.fastcampus.applicationclient.fixture.createOrderFixture
+import org.fastcampus.order.entity.Order
+import org.fastcampus.order.exception.OrderException
+import org.fastcampus.order.repository.OrderRepository
+import org.fastcampus.payment.service.RefundManager
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.doNothing
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import strikt.api.expectThat
+import strikt.api.expectThrows
+import strikt.assertions.isEqualTo
+
+@ExtendWith(MockitoExtension::class)
+class OrderCancellationServiceTest {
+    @Mock lateinit var orderRepository: OrderRepository
+
+    @Mock lateinit var refundManager: RefundManager
+
+    @InjectMocks lateinit var orderCancellationService: OrderCancellationService
+
+    @Test
+    fun `cancel order`() {
+        // given
+        val order = createOrderFixture().copy(status = Order.Status.RECEIVE)
+
+        `when`(orderRepository.findById(order.id)).thenReturn(order)
+        doNothing().`when`(refundManager).refundOrder(order.id)
+
+        // when
+        orderCancellationService.cancelOrder(order.id)
+
+        verify(orderRepository).findById(order.id)
+        expectThat(order.status).isEqualTo(Order.Status.CANCEL)
+    }
+
+    @Test
+    fun `must throw exception when order is cancelled which has not RECEIVE status`() {
+        // given
+        var order = createOrderFixture()
+        order = order.copy(status = Order.Status.REFUSE)
+
+        `when`(orderRepository.findById(order.id)).thenReturn(order)
+
+        // when & then
+        expectThrows<OrderException.OrderCanNotCancelled> {
+            orderCancellationService.cancelOrder(order.id)
+        }.and {
+            get { orderId }.isEqualTo(order.id)
+            get { message }.isEqualTo("해당 주문은 취소할 수 없습니다.")
+        }
+        verify(orderRepository).findById(order.id)
+        verify(orderRepository, never()).save(order)
+    }
+}

--- a/domains/order/src/main/kotlin/org/fastcampus/order/entity/Order.kt
+++ b/domains/order/src/main/kotlin/org/fastcampus/order/entity/Order.kt
@@ -34,6 +34,13 @@ data class Order(
         this.status = Status.ACCEPT
     }
 
+    fun cancel() {
+        if (this.status != Status.RECEIVE) {
+            throw OrderException.OrderCanNotCancelled(this.id)
+        }
+        this.status = Status.CANCEL
+    }
+
     enum class Status(
         val code: String,
         val desc: String,

--- a/domains/order/src/main/kotlin/org/fastcampus/order/exception/OrderException.kt
+++ b/domains/order/src/main/kotlin/org/fastcampus/order/exception/OrderException.kt
@@ -5,6 +5,8 @@ open class OrderException(message: String) : RuntimeException(message) {
 
     data class OrderCanNotAccept(val orderId: String) : OrderException("주문 수락이 불가능한 주문입니다.")
 
+    data class OrderCanNotCancelled(val orderId: String) : OrderException("해당 주문은 취소할 수 없습니다.")
+
     data class StoreNotFound(val storeId: String) : OrderException("가게를 찾을 수 없습니다.")
 
     data class StoreClosed(val storeId: String) : OrderException("가게의 영업이 종료되어 주문이 불가능합니다.")

--- a/domains/payment/src/main/kotlin/org/fastcampus/payment/entity/Refund.kt
+++ b/domains/payment/src/main/kotlin/org/fastcampus/payment/entity/Refund.kt
@@ -1,0 +1,27 @@
+package org.fastcampus.payment.entity
+
+data class Refund(
+    val id: Long? = null,
+    val status: Status,
+    val orderId: String,
+) {
+    fun fail(): Refund {
+        if (this.status == Status.COMPLETE) {
+            throw IllegalStateException("이미 환불 완료된 거래입니다.")
+        }
+        return Refund(id, Status.FAIL, orderId)
+    }
+
+    fun complete(): Refund {
+        return Refund(id, Status.COMPLETE, orderId)
+    }
+
+    enum class Status(
+        val code: String,
+        val decs: String,
+    ) {
+        WAIT("f1", "환불대기"),
+        COMPLETE("f2", "환불완료"),
+        FAIL("f3", "환불실패"),
+    }
+}

--- a/domains/payment/src/main/kotlin/org/fastcampus/payment/exception/RefundException.kt
+++ b/domains/payment/src/main/kotlin/org/fastcampus/payment/exception/RefundException.kt
@@ -1,0 +1,5 @@
+package org.fastcampus.payment.exception
+
+open class RefundException(message: String) : RuntimeException(message) {
+    data class RefundNotFound(val id: Long) : RefundException("결제 정보를 찾을 수 없습니다.")
+}

--- a/domains/payment/src/main/kotlin/org/fastcampus/payment/repository/RefundRepository.kt
+++ b/domains/payment/src/main/kotlin/org/fastcampus/payment/repository/RefundRepository.kt
@@ -1,0 +1,11 @@
+package org.fastcampus.payment.repository
+
+import org.fastcampus.payment.entity.Refund
+
+interface RefundRepository {
+    fun findById(id: Long): Refund
+
+    fun save(refund: Refund): Refund
+
+    fun findAllByStatuses(statuses: List<Refund.Status>): List<Refund>
+}

--- a/domains/payment/src/main/kotlin/org/fastcampus/payment/service/RefundManager.kt
+++ b/domains/payment/src/main/kotlin/org/fastcampus/payment/service/RefundManager.kt
@@ -1,0 +1,43 @@
+package org.fastcampus.payment.service
+
+import org.fastcampus.payment.entity.Refund
+import org.fastcampus.payment.repository.RefundRepository
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class RefundManager(
+    private val refundRepository: RefundRepository,
+) {
+    companion object {
+        private val log = LoggerFactory.getLogger(RefundManager::class.java)
+    }
+
+    fun refundOrder(orderId: String) {
+        val refund = Refund(status = Refund.Status.WAIT, orderId = orderId)
+        refundRepository.save(refund)
+    }
+
+    @Scheduled(fixedDelay = 60000)
+    private fun processFailedRefunds() {
+        val failedRefunds = refundRepository.findAllByStatuses(listOf(Refund.Status.WAIT, Refund.Status.FAIL))
+        for (refund in failedRefunds) {
+            try {
+                if (requestRefund(refund)) {
+                    refundRepository.save(refund.complete())
+                } else {
+                    refundRepository.save(refund.fail())
+                }
+            } catch (e: Exception) {
+                log.error("환불 재처리 실패, orderId: ${refund.orderId}")
+                refundRepository.save(refund.fail())
+            }
+        }
+    }
+
+    private fun requestRefund(refund: Refund): Boolean {
+        // TODO 결제 PG사 연동 관련으로 차후 결제 API 명세서가 나오면 작성 진행
+        return true
+    }
+}

--- a/infrastructure/order-postgres/src/main/kotlin/org/fastcampus/order/postgres/entity/OrderJpaEntity.kt
+++ b/infrastructure/order-postgres/src/main/kotlin/org/fastcampus/order/postgres/entity/OrderJpaEntity.kt
@@ -6,6 +6,7 @@ import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import jakarta.persistence.Version
 import org.fastcampus.common.entity.BaseEntity
 import org.fastcampus.order.entity.Order
 import java.time.LocalDateTime
@@ -54,6 +55,8 @@ class OrderJpaEntity(
     val deliveryPrice: Long? = 0L,
     @Column(name = "PAYMENT_PRICE")
     val paymentPrice: Long,
+    @Version
+    val version: Long? = null,
 ) : BaseEntity()
 
 fun Order.toJpaEntity() =

--- a/infrastructure/payment-postgres/src/main/kotlin/org/fastcampus/payment/postgres/entity/RefundJpaEntity.kt
+++ b/infrastructure/payment-postgres/src/main/kotlin/org/fastcampus/payment/postgres/entity/RefundJpaEntity.kt
@@ -1,0 +1,39 @@
+package org.fastcampus.payment.postgres.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.fastcampus.common.entity.BaseEntity
+import org.fastcampus.payment.entity.Refund
+
+@Entity
+@Table(name = "REFUNDS")
+class RefundJpaEntity(
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    val id: Long? = null,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "STATUS")
+    val status: Refund.Status,
+    @Column(name = "ORDER_ID")
+    val orderId: String,
+) : BaseEntity()
+
+fun Refund.toJpaEntity() =
+    RefundJpaEntity(
+        id,
+        status,
+        orderId,
+    )
+
+fun RefundJpaEntity.toModel() =
+    Refund(
+        id,
+        status,
+        orderId,
+    )

--- a/infrastructure/payment-postgres/src/main/kotlin/org/fastcampus/payment/postgres/repository/RefundJpaRepository.kt
+++ b/infrastructure/payment-postgres/src/main/kotlin/org/fastcampus/payment/postgres/repository/RefundJpaRepository.kt
@@ -1,0 +1,9 @@
+package org.fastcampus.payment.postgres.repository
+
+import org.fastcampus.payment.entity.Refund
+import org.fastcampus.payment.postgres.entity.RefundJpaEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface RefundJpaRepository : JpaRepository<RefundJpaEntity, Long> {
+    fun findAllByStatusIn(string: List<Refund.Status>): List<RefundJpaEntity>
+}

--- a/infrastructure/payment-postgres/src/main/kotlin/org/fastcampus/payment/postgres/repository/RefundRepositoryCustom.kt
+++ b/infrastructure/payment-postgres/src/main/kotlin/org/fastcampus/payment/postgres/repository/RefundRepositoryCustom.kt
@@ -1,0 +1,26 @@
+package org.fastcampus.payment.postgres.repository
+
+import org.fastcampus.payment.entity.Refund
+import org.fastcampus.payment.exception.RefundException
+import org.fastcampus.payment.postgres.entity.toJpaEntity
+import org.fastcampus.payment.postgres.entity.toModel
+import org.fastcampus.payment.repository.RefundRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+@Repository
+class RefundRepositoryCustom(
+    private val refundJpaRepository: RefundJpaRepository,
+) : RefundRepository {
+    override fun findById(id: Long): Refund {
+        return refundJpaRepository.findByIdOrNull(id)?.toModel() ?: throw RefundException.RefundNotFound(id)
+    }
+
+    override fun save(refund: Refund): Refund {
+        return refundJpaRepository.save(refund.toJpaEntity()).toModel()
+    }
+
+    override fun findAllByStatuses(statuses: List<Refund.Status>): List<Refund> {
+        return refundJpaRepository.findAllByStatusIn(statuses).map { it.toModel() }
+    }
+}


### PR DESCRIPTION
주문 취소 및 주문 취소시에 발생되는 환불에 대해서 구현하였습니다.
2가지 부분에 중점을 두었는데 피드백 요청드립니다.

1. 주문취소와 주문수락, 거절의 동시성 이슈
   - 이 동시성 이슈에 대해서 @Retryable과 @Recover 어노테이션 및 @Version을 통해서 낙관적락으로 풀어갔습니다. 이 부분에 대해서 코드 읽어보시고 이해가 난해하다면 답글부탁드립니다.

2. 주문취소 시 환불
   - 최초 주문 취소 시, 환불 API를 바로 부르지 않고 환불 대기 상태로 db 적재만 진행합니다(이후 스케줄러에 의해 환불 API 호출). 이 부분에서 비동기로 진행하려 했으나 다음과 같은 점이 걸려 진행하지 않았습니다. 혹시 좋은 방안 있으시면 말씀해주시면 감사하겠습니다.
      - 주문취소와 환불은 Transaction으로 묶여야한다. 따라서 환불 API를 비동기로 호출해도 동기적으로 쓰는거나 마찬가지로 판단 